### PR TITLE
Don't use script in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,5 @@ matrix:
     allow_failures:
         - julia: nightly
 sudo: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'if VERSION >= v"0.7" using Pkg; Pkg.build() else Pkg.clone(pwd()) end'
-    - julia -e 'if VERSION >= v"0.7" using Pkg end; Pkg.test("YAML", coverage=true)'
 after_success:
     - julia -e 'if VERSION >= v"0.7" using Pkg end; cd(Pkg.dir("YAML")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
Not sure why it's nessecery, and it may fix the errors master is causing for 0.7 and 1.0 on travis.