### PR TITLE
improve performance by 2x

### DIFF
--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -17,9 +17,9 @@ end
 
 
 # Read and buffer n more characters
-function _fill(bi::BufferedInput, n::Integer)
+function __fill(bi::BufferedInput, bi_input::IO, n::Integer)
     for i in 1:n
-        c = eof(bi.input) ? '\0' : read(bi.input, Char)
+        c = eof(bi_input) ? '\0' : read(bi_input, Char)
         if bi.offset + bi.avail + 1 <= length(bi.buffer)
             bi.buffer[bi.offset + bi.avail + 1] = c
         else
@@ -29,6 +29,7 @@ function _fill(bi::BufferedInput, n::Integer)
     end
 end
 
+_fill(bi::BufferedInput, n::Integer) = __fill(bi, bi.input, n)
 
 # Peek the character in the i-th position relative to the current position.
 # (0-based)
@@ -46,7 +47,7 @@ function prefix(bi::BufferedInput, n::Integer=1)
     if bi.avail < n + 1
         _fill(bi, n + 1 - bi.avail)
     end
-    return string(bi.buffer[Int(bi.offset + 1):Int(bi.offset + n)]...)
+    return string(bi.buffer[(bi.offset + 1):(bi.offset + n)]...)
 end
 
 

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -4,11 +4,11 @@ include("resolver.jl")
 
 
 struct ComposerError
-    context::Union{AbstractString, Nothing}
+    context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}
-    problem::Union{AbstractString, Nothing}
+    problem::Union{String, Nothing}
     problem_mark::Union{Mark, Nothing}
-    note::Union{AbstractString, Nothing}
+    note::Union{String, Nothing}
 
     function ComposerError(context=nothing, context_mark=nothing,
                            problem=nothing, problem_mark=nothing,
@@ -27,13 +27,13 @@ end
 
 mutable struct Composer
     input::EventStream
-    anchors::Dict{AbstractString, Node}
+    anchors::Dict{String, Node}
     resolver::Resolver
 end
 
 
 function compose(events)
-    composer = Composer(events, Dict{AbstractString, Node}(), Resolver())
+    composer = Composer(events, Dict{String, Node}(), Resolver())
     @assert typeof(forward!(composer.input)) == StreamStartEvent
     node = compose_document(composer)
     if typeof(peek(composer.input)) == StreamEndEvent
@@ -90,7 +90,7 @@ function compose_node(composer::Composer, parent::Union{Node, Nothing},
 end
 
 
-function compose_scalar_node(composer::Composer, anchor::Union{AbstractString, Nothing})
+function compose_scalar_node(composer::Composer, anchor::Union{String, Nothing})
     event = forward!(composer.input)
     tag = event.tag
     if tag === nothing || tag == "!"
@@ -108,7 +108,7 @@ function compose_scalar_node(composer::Composer, anchor::Union{AbstractString, N
 end
 
 
-function compose_sequence_node(composer::Composer, anchor::Union{AbstractString, Nothing})
+function compose_sequence_node(composer::Composer, anchor::Union{String, Nothing})
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"
@@ -135,7 +135,7 @@ function compose_sequence_node(composer::Composer, anchor::Union{AbstractString,
 end
 
 
-function compose_mapping_node(composer::Composer, anchor::Union{AbstractString, Nothing})
+function compose_mapping_node(composer::Composer, anchor::Union{String, Nothing})
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -46,7 +46,7 @@ function construct_document(constructor::Constructor, node::Node)
 end
 
 
-function construct_object(constructor::Constructor, node::Node; deep=false)
+function construct_object(constructor::Constructor, node::Node, deep=false)
     if haskey(constructor.constructed_objects, node)
         return constructor.constructed_objects[node]
     end
@@ -109,14 +109,14 @@ function construct_scalar(constructor::Constructor, node::Node)
 end
 
 
-function construct_sequence(constructor::Constructor, node::Node; deep=false)
+function construct_sequence(constructor::Constructor, node::Node, deep=false)
     if typeof(node) != SequenceNode
         throw(ConstructorError(nothing, nothing,
                                "expected a sequence node, but found $(typeof(node))",
                                node.start_mark))
     end
 
-    [construct_object(constructor, child, deep=deep) for child in node.value]
+    [construct_object(constructor, child, deep) for child in node.value]
 end
 
 
@@ -160,7 +160,7 @@ function flatten_mapping(node::MappingNode)
 end
 
 
-function construct_mapping(constructor::Constructor, node::Node; deep=false)
+function construct_mapping(constructor::Constructor, node::Node, deep=false)
     if typeof(node) != MappingNode
         throw(ConstructorError(nothing, nothing,
                                "expected a mapping node, but found $(typeof(node))",
@@ -170,8 +170,8 @@ function construct_mapping(constructor::Constructor, node::Node; deep=false)
     flatten_mapping(node)
     mapping = Dict()
     for (key_node, value_node) in node.value
-        key = construct_object(constructor, key_node, deep=deep)
-        value = construct_object(constructor, value_node, deep=deep)
+        key = construct_object(constructor, key_node, deep)
+        value = construct_object(constructor, value_node, deep)
         mapping[key] = value
     end
     mapping

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -1,10 +1,10 @@
 
 struct ConstructorError
-    context::Union{AbstractString, Nothing}
+    context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}
-    problem::Union{AbstractString, Nothing}
+    problem::Union{String, Nothing}
     problem_mark::Union{Mark, Nothing}
-    note::Union{AbstractString, Nothing}
+    note::Union{String, Nothing}
 
     function ConstructorError(context=nothing, context_mark=nothing,
                               problem=nothing, problem_mark=nothing,
@@ -26,16 +26,16 @@ mutable struct Constructor
     constructed_objects::Dict{Node, Any}
     recursive_objects::Set{Node}
     deep_construct::Bool
-    yaml_constructors::Dict{Union{AbstractString, Nothing}, Function}
+    yaml_constructors::Dict{Union{String, Nothing}, Function}
 
-    function Constructor(more_constructors::Dict{AbstractString,Function})
+    function Constructor(more_constructors::Dict{String,Function})
         new(Dict{Node, Any}(), Set{Node}(), false,
             merge(copy(default_yaml_constructors), more_constructors))
     end
 end
 
-Constructor() = Constructor(Dict{AbstractString,Function}())
-Constructor(::Nothing) = Constructor(Dict{AbstractString,Function}())
+Constructor() = Constructor(Dict{String,Function}())
+Constructor(::Nothing) = Constructor(Dict{String,Function}())
 
 function construct_document(constructor::Constructor, node::Node)
     data = construct_object(constructor, node)
@@ -207,7 +207,7 @@ function construct_yaml_int(constructor::Constructor, node::Node)
         # TODO
         #throw(ConstructorError(nothing, nothing,
             #"sexagesimal integers not yet implemented", node.start_mark))
-        warn("sexagesimal integers not yet implemented. Returning AbstractString.")
+        warn("sexagesimal integers not yet implemented. Returning String.")
         return value
     end
 
@@ -229,7 +229,7 @@ function construct_yaml_float(constructor::Constructor, node::Node)
         # TODO
         # throw(ConstructorError(nothing, nothing,
         #     "sexagesimal floats not yet implemented", node.start_mark))
-        warn("sexagesimal floats not yet implemented. Returning AbstractString.")
+        warn("sexagesimal floats not yet implemented. Returning String.")
         return value
     end
 
@@ -371,7 +371,7 @@ function construct_yaml_binary(constructor::Constructor, node::Node)
     Codecs.decode(Codecs.Base64, value)
 end
 
-const default_yaml_constructors = Dict{Union{AbstractString, Nothing}, Function}(
+const default_yaml_constructors = Dict{Union{String, Nothing}, Function}(
         "tag:yaml.org,2002:null"      => construct_yaml_null,
         "tag:yaml.org,2002:bool"      => construct_yaml_bool,
         "tag:yaml.org,2002:int"       => construct_yaml_int,

--- a/src/events.jl
+++ b/src/events.jl
@@ -4,7 +4,7 @@ abstract type Event end
 struct StreamStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    encoding::AbstractString
+    encoding::String
 end
 
 
@@ -19,7 +19,7 @@ struct DocumentStartEvent <: Event
     end_mark::Mark
     explicit::Bool
     version::Union{Tuple, Nothing}
-    tags::Union{Dict{AbstractString, AbstractString}, Nothing}
+    tags::Union{Dict{String, String}, Nothing}
 
     function DocumentStartEvent(start_mark::Mark,end_mark::Mark,
                                 explicit::Bool, version=nothing,
@@ -39,17 +39,17 @@ end
 struct AliasEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union{AbstractString, Nothing}
+    anchor::Union{String, Nothing}
 end
 
 
 struct ScalarEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union{AbstractString, Nothing}
-    tag::Union{AbstractString, Nothing}
+    anchor::Union{String, Nothing}
+    tag::Union{String, Nothing}
     implicit::Tuple
-    value::AbstractString
+    value::String
     style::Union{Char, Nothing}
 end
 
@@ -57,8 +57,8 @@ end
 struct SequenceStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union{AbstractString, Nothing}
-    tag::Union{AbstractString, Nothing}
+    anchor::Union{String, Nothing}
+    tag::Union{String, Nothing}
     implicit::Bool
     flow_style::Bool
 end
@@ -73,8 +73,8 @@ end
 struct MappingStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union{AbstractString, Nothing}
-    tag::Union{AbstractString, Nothing}
+    anchor::Union{String, Nothing}
+    tag::Union{String, Nothing}
     implicit::Bool
     flow_style::Bool
 end

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -2,8 +2,8 @@
 abstract type Node end
 
 mutable struct ScalarNode <: Node
-    tag::AbstractString
-    value::AbstractString
+    tag::String
+    value::String
     start_mark::Union{Mark, Nothing}
     end_mark::Union{Mark, Nothing}
     style::Union{Char, Nothing}
@@ -11,7 +11,7 @@ end
 
 
 mutable struct SequenceNode <: Node
-    tag::AbstractString
+    tag::String
     value::Vector
     start_mark::Union{Mark, Nothing}
     end_mark::Union{Mark, Nothing}
@@ -20,7 +20,7 @@ end
 
 
 mutable struct MappingNode <: Node
-    tag::AbstractString
+    tag::String
     value::Vector
     start_mark::Union{Mark, Nothing}
     end_mark::Union{Mark, Nothing}

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,15 +1,15 @@
 
 include("events.jl")
 
-const DEFAULT_TAGS = Dict{AbstractString,AbstractString}("!" => "!", "!!" => "tag:yaml.org,2002:")
+const DEFAULT_TAGS = Dict{String,String}("!" => "!", "!!" => "tag:yaml.org,2002:")
 
 
 struct ParserError
-    context::Union{AbstractString, Nothing}
+    context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}
-    problem::Union{AbstractString, Nothing}
+    problem::Union{String, Nothing}
     problem_mark::Union{Mark, Nothing}
-    note::Union{AbstractString, Nothing}
+    note::Union{String, Nothing}
 
     function ParserError(context=nothing, context_mark=nothing,
                          problem=nothing, problem_mark=nothing,
@@ -33,12 +33,12 @@ mutable struct EventStream
     states::Vector{Function}
     marks::Vector{Mark}
     yaml_version::Union{Tuple, Nothing}
-    tag_handles::Dict{AbstractString, AbstractString}
+    tag_handles::Dict{String, String}
     end_of_stream::Union{StreamEndEvent, Nothing}
 
     function EventStream(input::TokenStream)
         new(input, nothing, parse_stream_start, Function[], Mark[],
-            nothing, Dict{AbstractString, AbstractString}(), nothing)
+            nothing, Dict{String, String}(), nothing)
     end
 end
 
@@ -82,7 +82,7 @@ end
 
 function process_directives(stream::EventStream)
     stream.yaml_version = nothing
-    stream.tag_handles = Dict{AbstractString, AbstractString}()
+    stream.tag_handles = Dict{String, String}()
     while typeof(peek(stream.input)) == DirectiveToken
         token = forward!(stream.input)
         if token.name == "YAML"

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -214,7 +214,7 @@ end
 
 
 function parse_block_node(stream::EventStream)
-    parse_node(stream, block=true)
+    parse_node(stream, true)
 end
 
 
@@ -224,11 +224,11 @@ end
 
 
 function parse_block_node_or_indentless_sequence(stream::EventStream)
-    parse_node(stream, block=true, indentless_sequence=true)
+    parse_node(stream, true, true)
 end
 
 
-function parse_node(stream::EventStream; block=false, indentless_sequence=false)
+function parse_node(stream::EventStream, block=false, indentless_sequence=false)
     token = peek(stream.input)
     if typeof(token) == AliasToken
         forward!(stream.input)
@@ -445,11 +445,11 @@ end
 function parse_flow_sequence_first_entry(stream::EventStream)
     token = forward!(stream.input)
     push!(stream.marks, token.span.start_mark)
-    parse_flow_sequence_entry(stream, first_entry=true)
+    parse_flow_sequence_entry(stream, true)
 end
 
 
-function parse_flow_sequence_entry(stream::EventStream; first_entry=false)
+function parse_flow_sequence_entry(stream::EventStream, first_entry=false)
     token = peek(stream.input)
     if typeof(token) != FlowSequenceEndToken
         if !first_entry
@@ -521,11 +521,11 @@ end
 function parse_flow_mapping_first_key(stream::EventStream)
     token = forward!(stream.input)
     push!(stream.marks, token.span.start_mark)
-    parse_flow_mapping_key(stream, first_entry=true)
+    parse_flow_mapping_key(stream, true)
 end
 
 
-function parse_flow_mapping_key(stream::EventStream; first_entry=false)
+function parse_flow_mapping_key(stream::EventStream, first_entry=false)
     token = peek(stream.input)
     if typeof(token) != FlowMappingEndToken
         if !first_entry

--- a/src/resolver.jl
+++ b/src/resolver.jl
@@ -59,7 +59,7 @@ const default_implicit_resolvers =
 
 
 mutable struct Resolver
-    implicit_resolvers::Vector
+    implicit_resolvers::Vector{Tuple{String,Regex}}
 
     function Resolver()
         new(copy(default_implicit_resolvers))

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -31,9 +31,9 @@ end
 
 # Errors thrown by the scanner.
 struct ScannerError <: Exception
-    context::Union{AbstractString, Nothing}
+    context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}
-    problem::AbstractString
+    problem::String
     problem_mark::Mark
 end
 
@@ -1439,7 +1439,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
 end
 
 
-function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_tag_handle(stream::TokenStream, name::String, start_mark::Mark)
     c = peek(stream.input)
     if c != '!'
         throw(ScannerError("while scanning a $(name)", start_mark,
@@ -1468,7 +1468,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
 end
 
 
-function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_tag_uri(stream::TokenStream, name::String, start_mark::Mark)
     chunks = Any[]
     length = 0
     c = peek(stream.input, length)
@@ -1500,7 +1500,7 @@ function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mar
 end
 
 
-function scan_uri_escapes(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_uri_escapes(stream::TokenStream, name::String, start_mark::Mark)
     bytes = Any[]
     mark = get_mark(stream)
     while peek(stream.input) == '%'

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -96,7 +96,7 @@ mutable struct TokenStream
     #   (token_number, required, index, line, column, mark)
     # A simple key may start with ALIAS, ANCHOR, TAG, SCALAR(flow),
     # '[', or '{' tokens.
-    possible_simple_keys::Dict
+    possible_simple_keys::Dict{UInt64,SimpleKey}
 
     function TokenStream(stream::IO)
         tokstream = new(BufferedInput(stream), false, Queue{Token}(),

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -7,7 +7,7 @@ abstract type Token end
 # The '%YAML' directive.
 struct DirectiveToken <: Token
     span::Span
-    name::AbstractString
+    name::String
     value::Union{Tuple, Nothing}
 end
 
@@ -24,7 +24,7 @@ end
 # The stream start
 struct StreamStartToken <: Token
     span::Span
-    encoding::AbstractString
+    encoding::String
 end
 
 # The stream end
@@ -90,13 +90,13 @@ end
 # '*anchor'
 struct AliasToken <: Token
     span::Span
-    value::AbstractString
+    value::String
 end
 
 # '&anchor'
 struct AnchorToken <: Token
     span::Span
-    value::AbstractString
+    value::String
 end
 
 # '!handle!suffix'
@@ -108,7 +108,7 @@ end
 # A scalar.
 struct ScalarToken <: Token
     span::Span
-    value::AbstractString
+    value::String
     plain::Bool
     style::Union{Char, Nothing}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,7 @@ end
 const more_constructors = let
     pairs = [("!Cartesian", :Cartesian),
              ("!AR1", :AR1)]
-    Dict{AbstractString,Function}([(t, (c, n) -> construct_type_map(s, c, n))
+    Dict{String,Function}([(t, (c, n) -> construct_type_map(s, c, n))
                            for (t, s) in pairs])
 end
 


### PR DESCRIPTION
a speed test on my test data set with this PR is 2.979 sec.  on master it is 5.934 sec.  with [PyYAML](https://pyyaml.org) it is 4.071 sec for the wrapper around the libyaml C code, or 24.03 sec for the pure python code.

```
# python test script
from yaml import load, dump
from yaml import CLoader as Loader, CDumper as Dumper
import time
fid=open('foo.yml','r')
t0=time.time(); load(fid, Loader=Loader); print(time.time()-t0)
```

worth noting that C code which implements a custom parser that is specific to this test set's document structure can read this file in 0.25 sec.  so there is a lot of overhead for generality.