### PR TITLE
Drop support for Julia versions before 1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: julia
 os:
     - linux
+    - osx
+    - windows
 julia:
-    - 0.6
-    - 0.7
     - 1.0
+    - 1.4
     - nightly
 notifications:
     email: false
@@ -12,5 +13,4 @@ matrix:
     allow_failures:
         - julia: nightly
 sudo: false
-after_success:
-    - julia -e 'if VERSION >= v"0.7" using Pkg end; cd(Pkg.dir("YAML")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,18 @@
 name = "YAML"
 uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Codecs = "19ecbf4d-ef7c-5e4b-b54a-0a0ff23c5aed"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-Compat = "≥ 0.65.0"
-julia = "≥ 0.6.0"
+Codecs = "0.5"
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,11 @@ uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 version = "0.4.0"
 
 [deps]
-Codecs = "19ecbf4d-ef7c-5e4b-b54a-0a0ff23c5aed"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-Codecs = "0.5"
 julia = "1"
 
 [extras]

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -6,7 +6,7 @@ import Base: isempty, length, show
 
 import Base: iterate
 
-import Codecs
+using Base64: base64decode
 using Dates
 using Printf
 

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -4,24 +4,11 @@ module YAML
 
 import Base: isempty, length, show
 
-if VERSION < v"1.0.0-rc1.0"
-    import Base: start, next, done
-else
-    import Base: iterate
-end
+import Base: iterate
 
 import Codecs
-using Compat
-using Compat.Dates
-using Compat.Printf
-
-if VERSION < v"0.7.0-DEV.2915"
-    isnumeric(c::Char) = isnumber(c)
-end
-
-if VERSION < v"0.7.0-DEV.3526"
-    Base.parse(T::Type{Int}, s::AbstractString; base = 10) = parse(T, s, base)
-end
+using Dates
+using Printf
 
 include("scanner.jl")
 include("parser.jl")

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -368,7 +368,7 @@ end
 
 function construct_yaml_binary(constructor::Constructor, node::Node)
     value = replace(string(construct_scalar(constructor, node)), "\n" => "")
-    Codecs.decode(Codecs.Base64, value)
+    base64decode(value)
 end
 
 const default_yaml_constructors = Dict{Union{String, Nothing}, Function}(

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -126,7 +126,7 @@ function flatten_mapping(node::MappingNode)
     while index <= length(node.value)
         key_node, value_node = node.value[index]
         if key_node.tag == "tag:yaml.org,2002:merge"
-            node.value = node.value[setdiff(Compat.axes(node.value, 1), index)]
+            node.value = node.value[setdiff(axes(node.value, 1), index)]
             if typeof(value_node) == MappingNode
                 flatten_mapping(value_node)
                 append!(merge, value_node.value)

--- a/test/issue30.expected
+++ b/test/issue30.expected
@@ -1,5 +1,4 @@
-using Compat
-@compat Dict{Any,Any}(
+Dict{Any,Any}(
   "x" => 1,
   "y" => 2,
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ module YAMLTests
 
 import YAML
 import Base.Filesystem
-using Compat.Test
+using Test
 
 const tests = [
     "spec-02-01",

--- a/test/spec-02-11.expected
+++ b/test/spec-02-11.expected
@@ -1,4 +1,4 @@
-using Compat.Dates
+using Dates
 
 Dict{Any,Any}(
  Any["Detroit Tigers", "Chicago cubs"] =>

--- a/test/spec-02-22.expected
+++ b/test/spec-02-22.expected
@@ -1,4 +1,4 @@
-using Compat.Dates
+using Dates
 
 Dict{Any,Any}(
     "canonical" => DateTime(2001, 12, 15, 2,  59, 43, 100),

--- a/test/spec-02-23.expected
+++ b/test/spec-02-23.expected
@@ -1,9 +1,8 @@
-using Codecs
+using Base64
 Dict{Any,Any}(
     "not-date" => "2002-04-28",
     "picture" =>
-        decode(Base64,
-         "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs=")
+        base64decode("R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs=")
 
     ## Disabled since we don't really support custom tags
     #"application specific tag" =>


### PR DESCRIPTION
* Drop support for Julia versions before 1.0.
* Remove Compat dependency.
* Update Project.toml to allow auto-merge to General registry.
* Update Travis configuration.
* Replace Codecs dependency with Base64 stdlib.
* Bump version to 0.4.0.
